### PR TITLE
Module/plan

### DIFF
--- a/src/plans/plan.dto.ts
+++ b/src/plans/plan.dto.ts
@@ -10,8 +10,8 @@ export class CreatePlanDto {
     @IsNotEmpty()
     @IsArray()
     @IsNumber({}, { each: true })
-    @ArrayMinSize(2, { message: 'Give me longitude and latitude'})
-    @ArrayMaxSize(2, { message: 'Give me longitude and latitude'})
+    @ArrayMinSize(2, { message: 'Give me longitude and latitude of source'})
+    @ArrayMaxSize(2, { message: 'Give me longitude and latitude of source'})
     source: number[];
 
     @ApiProperty()

--- a/src/plans/plan.dto.ts
+++ b/src/plans/plan.dto.ts
@@ -1,11 +1,19 @@
 import { ApiProperty, PartialType } from "@nestjs/swagger";
-import { IsDateString, IsNotEmpty, IsOptional, IsString, Min } from "class-validator";
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsDateString, IsNotEmpty, IsNumber, IsOptional, IsString, Min } from "class-validator";
 
 export class CreatePlanDto {
     @ApiProperty()
     @IsOptional()
     name?: string;
-    
+
+    @ApiProperty()
+    @IsNotEmpty()
+    @IsArray()
+    @IsNumber({}, { each: true })
+    @ArrayMinSize(2, { message: 'Give me longitude and latitude'})
+    @ArrayMaxSize(2, { message: 'Give me longitude and latitude'})
+    source: number[];
+
     @ApiProperty()
     @IsOptional()
     destination?: string;
@@ -38,6 +46,7 @@ export class CreatePlanDto {
     @ApiProperty()
     @IsNotEmpty()
     @IsString({each: true})
+    @ArrayMinSize(1)
     preferredTags: string[];
 }
 

--- a/src/plans/plans.service.ts
+++ b/src/plans/plans.service.ts
@@ -11,9 +11,38 @@ export class PlansService {
 
   create(createPlanDto: CreatePlanDto) {
     const currentUserId = "002";
-    const newPlan = new this.planModel({ ...createPlanDto, ownerId: currentUserId});
+    // now dto has some field of data but we will have to do somethings to make it a complete plan then insert
+    // do what??????
+
+    // let us check first what tags user provided
+
+    if (!createPlanDto.budget){
+      // check previous plan to get average budget???
+      // default set to some value like 1000??
+      // or make it lowest for the cheapest plan or make it infinite for the most expensive plan???
+      // or just sum all place price after got complete plan (Procrastinate)
+      createPlanDto.budget = 0;
+    } 
+    if (!createPlanDto.startTime){
+      // pick the best datetime for user
+      // or will we receive as period when user can go and then we pick date from that???
+      createPlanDto.startTime = new Date();
+    }
+    if (!createPlanDto.endTime){
+      createPlanDto.endTime = new Date();
+    }
+    let dst = [0, 0];
+    if (!createPlanDto.destination){
+      // some logic to pick the best match place?
+      dst = [0, 0];
+    }
+
+    const newPlan = new this.planModel({ ...createPlanDto, ownerId: currentUserId, destination: dst });
+    console.log(createPlanDto);
     return newPlan.save();
   }
+
+
 
   findAll() {
     return this.planModel.find().exec();

--- a/src/schemas/plan.schema.ts
+++ b/src/schemas/plan.schema.ts
@@ -14,7 +14,7 @@ export class Plan{
 
     @Prop({ required: true, type: [Number], validate: {
       validator: (value: number[]) => value.length == 2,
-      message: 'Destination must contain longitude and latitude.',
+      message: 'Destination must contain longitude and latitude of destination.',
     }})
     destination: number[];
 

--- a/src/schemas/plan.schema.ts
+++ b/src/schemas/plan.schema.ts
@@ -6,12 +6,20 @@ export type planDocument = HydratedDocument<Plan>;
 
 @Schema({ versionKey: false })
 export class Plan{
-    @Prop( {required: true})
-    name: string;
-
-    @Prop( {required: true})
-    destination: string;
+    @Prop()
+    name: string; // Removed `required: true` since it is auto-filled in the pre-save middleware
     
+    @Prop( {required: true, type: Date})
+
+    @Prop( {required: true, type: [Number]})
+    source: number[];
+
+    @Prop({ required: true, type: [Number], validate: {
+      validator: (value: number[]) => value.length == 2,
+      message: 'Destination must contain longitude and latitude.',
+    }})
+    destination: number[];
+
     @Prop( {required: true, type: Date})
     startTime: Date;
     
@@ -19,12 +27,12 @@ export class Plan{
     endTime: Date;
     
     @Prop( {required: true})
-    tags: string[];
+    preferredTags: string[];
     
     @Prop( {required: true})
     budget: number;
     
-    @Prop( {required: true})
+    @Prop( {required: true, default: 1})
     groupSize: number;
     
     @Prop( {required: true })

--- a/src/schemas/plan.schema.ts
+++ b/src/schemas/plan.schema.ts
@@ -8,8 +8,6 @@ export type planDocument = HydratedDocument<Plan>;
 export class Plan{
     @Prop()
     name: string; // Removed `required: true` since it is auto-filled in the pre-save middleware
-    
-    @Prop( {required: true, type: Date})
 
     @Prop( {required: true, type: [Number]})
     source: number[];

--- a/src/seed/seed.service.ts
+++ b/src/seed/seed.service.ts
@@ -14,7 +14,7 @@ export class SeedService {
     @InjectModel(User.name) private userModel: Model<UserDocument>,
     @InjectModel(TransportMethod.name) private transportModel: Model<TransportMethodDocument>,
   ) {}
-
+  // use 'npm run seed'
   async run() {
     await Promise.all([
         this.userModel.deleteMany({}),


### PR DESCRIPTION
This pull request introduces significant changes to how plans are created and validated, especially around location data and default values. The main updates include stricter validation for the `source` and `destination` fields, improved handling of optional and default values in the plan creation logic, and updates to the schema to reflect these changes.

**DTO and Validation Improvements:**
- Added `source` as a required array of two numbers (longitude and latitude) in `CreatePlanDto`, with validation to ensure exactly two values are provided. (`src/plans/plan.dto.ts` [src/plans/plan.dto.tsL2-R16](diffhunk://#diff-9a856947080b45b897ce0c9dd3b00b64b1e8435edb2479cbc18d34409da00e8bL2-R16))
- Updated `preferredTags` in `CreatePlanDto` to require at least one tag. (`src/plans/plan.dto.ts` [src/plans/plan.dto.tsR49](diffhunk://#diff-9a856947080b45b897ce0c9dd3b00b64b1e8435edb2479cbc18d34409da00e8bR49))

**Schema and Model Changes:**
- Changed `source` in the `Plan` schema to a required array of numbers, and updated `destination` to require exactly two numbers (longitude and latitude) with custom validation. (`src/schemas/plan.schema.ts` [src/schemas/plan.schema.tsL9-R19](diffhunk://#diff-8cdc5f91196ab293834ee2cdda9505572f5f5cd84e10ab532bd273cdef378581L9-R19))
- Renamed `tags` to `preferredTags` in the schema to match the DTO, and set a default value of 1 for `groupSize`. (`src/schemas/plan.schema.ts` [src/schemas/plan.schema.tsL22-R33](diffhunk://#diff-8cdc5f91196ab293834ee2cdda9505572f5f5cd84e10ab532bd273cdef378581L22-R33))
- Made `name` optional in the schema, as it is now auto-filled elsewhere. (`src/schemas/plan.schema.ts` [src/schemas/plan.schema.tsL9-R19](diffhunk://#diff-8cdc5f91196ab293834ee2cdda9505572f5f5cd84e10ab532bd273cdef378581L9-R19))

**Plan Creation Logic:**
- Enhanced the `create` method in `PlansService` to set default values for `budget`, `startTime`, and `endTime` if not provided, and to handle missing `destination` with a placeholder value. (`src/plans/plans.service.ts` [src/plans/plans.service.tsL14-R46](diffhunk://#diff-c3b665e03b7c19fbc4df5c7de1e00fbdd40cd8c0677b9a42ca022409f4bce549L14-R46))

**Miscellaneous:**
- Added a comment in the seed service to clarify usage. (`src/seed/seed.service.ts` [src/seed/seed.service.tsL17-R17](diffhunk://#diff-1c185832d2ca1da286e6ead5f6e09abed51866a64fefe724b7f7593cc4284c3dL17-R17))